### PR TITLE
fix comment regex

### DIFF
--- a/uxn.xml
+++ b/uxn.xml
@@ -41,7 +41,7 @@
         </list>
         <contexts>
             <context attribute="Normal Text" lineEndContext="#pop" name="Normal Text" >
-                <RegExpr attribute="Comment" context="#stay" String="\(.*\)" />
+                <RegExpr attribute="Comment" context="#stay" String="\((?:[^)(]+|(?R))*+\)" />
                 <RegExpr context="Device" lookAhead="true" String="(@|&amp;)([A-z]*)" />
                 <RegExpr context="Macro" lookAhead="true" String="(%)([A-z]*)" />
                 <RegExpr context="Padding" lookAhead="true" String="(\$|\||#)(([A-z]|[0-9])*)" />


### PR DESCRIPTION
Hi,

this pull request fixes regex for comments, for example, before

```
( this ( is ) a comment )
^^^^^^^^^^^^^
           \_ the comment would only match up to here
```

now it uses some PCRE magic i found on stackoverflow to match the parentheses correctly :)